### PR TITLE
Use a more appropriate icon

### DIFF
--- a/data/org.danctnix.Tweaks.svg
+++ b/data/org.danctnix.Tweaks.svg
@@ -6,36 +6,12 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    viewBox="0 0 128 128"
    style="display:inline;enable-background:new"
    version="1.0"
    id="svg11300"
    height="128"
-   width="128"
-   sodipodi:docname="org.danctnix.Tweaks.svg"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1043"
-     id="namedview35"
-     showgrid="false"
-     inkscape:zoom="0.8466361"
-     inkscape:cx="-468.88901"
-     inkscape:cy="107.1525"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="layer1" />
+   width="128">
   <title
      id="title4162">Adwaita Icon Template</title>
   <defs
@@ -154,111 +130,120 @@
      style="display:inline"
      id="layer1">
     <g
-       transform="translate(110)"
-       id="g1769">
-      <rect
-         ry="8"
-         rx="8"
-         y="204"
-         x="-98"
-         height="83.999992"
-         width="104"
-         id="rect1709"
-         style="display:inline;opacity:1;fill:url(#linearGradient1747);fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new" />
-      <rect
-         style="display:inline;opacity:1;fill:#f6f5f4;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new"
-         id="rect1711"
-         width="104"
-         height="100"
-         x="-98"
-         y="184"
-         rx="8"
-         ry="8" />
-    </g>
-    <path
-       style="vector-effect:none;fill:#419900;fill-opacity:1;stroke:none;stroke-width:0.853913;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 48,198 c -7.756,0 -14,6.244 -14,14 0,0.33768 0.0275,0.66844 0.05078,1 C 34.562237,205.71619 40.581684,200 48,200 h 32 c 7.418316,0 13.437763,5.71619 13.949219,13 C 93.9725,212.66844 94,212.33768 94,212 94,204.244 87.756,198 80,198 Z"
-       id="rect1790" />
-    <rect
-       ry="14"
-       rx="14"
-       y="200"
-       x="-94"
-       height="28"
-       width="59.999996"
-       id="rect1143"
-       style="vector-effect:none;fill:#53ce00;fill-opacity:1;stroke:none;stroke-width:0.853913;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       transform="scale(-1,1)" />
-    <g
-       id="g1151"
-       transform="matrix(-1,0,0,1,130,-6)">
-      <circle
-         transform="translate(0,4)"
-         r="14"
-         cy="218"
-         cx="50"
-         id="circle1147"
-         style="opacity:1;vector-effect:none;fill:#deddda;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         clip-path="url(#clipPath1784)" />
-      <rect
-         style="opacity:1;vector-effect:none;fill:#deddda;fill-opacity:1;stroke:none;stroke-width:0.881917;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         id="rect1149"
-         width="28"
-         height="5.9999995"
-         x="36"
-         y="216" />
-    </g>
-    <circle
-       r="14"
-       cy="210"
-       cx="-80"
-       id="circle1153"
-       style="vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.777778;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       transform="scale(-1,1)" />
-    <g
-       transform="matrix(-1,0,0,1,128,38)"
-       id="g1818">
-      <path
-         transform="translate(0,172)"
-         id="path1804"
-         d="m 48,28 c -7.756,0 -14,6.244 -14,14 0,0.337684 0.0275,0.668439 0.05078,1 C 34.562237,35.716191 40.581684,30 48,30 h 32 c 7.418316,0 13.437763,5.716191 13.949219,13 C 93.9725,42.668439 94,42.337684 94,42 94,34.244 87.756,28 80,28 Z"
-         style="opacity:1;vector-effect:none;fill:#9a9996;fill-opacity:1;stroke:none;stroke-width:0.853913;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-      <rect
-         ry="14"
-         rx="14"
-         y="202"
-         x="-94"
-         height="28"
-         width="59.999996"
-         id="rect1808"
-         style="opacity:1;vector-effect:none;fill:#c0bfbc;fill-opacity:1;stroke:none;stroke-width:0.853913;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         transform="scale(-1,1)" />
+       style="display:inline"
+       id="layer9">
       <g
-         transform="matrix(-1,0,0,1,130,-4)"
-         id="g1814">
-        <circle
-           clip-path="url(#clipPath1784)"
-           style="opacity:1;vector-effect:none;fill:#deddda;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-           id="circle1810"
-           cx="50"
-           cy="218"
-           r="14"
-           transform="translate(0,4)" />
+         transform="translate(110)"
+         id="g1769">
         <rect
-           y="216"
-           x="36"
-           height="5.9999995"
-           width="28"
-           id="rect1812"
-           style="opacity:1;vector-effect:none;fill:#deddda;fill-opacity:1;stroke:none;stroke-width:0.881917;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+           ry="8"
+           rx="8"
+           y="204"
+           x="-98"
+           height="83.999992"
+           width="104"
+           id="rect1709"
+           style="display:inline;opacity:1;fill:url(#linearGradient1747);fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new" />
+        <rect
+           style="display:inline;opacity:1;fill:#f6f5f4;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;enable-background:new"
+           id="rect1711"
+           width="104"
+           height="100"
+           x="-98"
+           y="184"
+           rx="8"
+           ry="8" />
       </g>
-      <circle
-         transform="scale(-1,1)"
-         style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.777778;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         id="circle1816"
-         cx="-80"
-         cy="212"
-         r="14" />
+      <g
+         transform="translate(0,-2)"
+         id="g1802">
+        <path
+           style="opacity:1;vector-effect:none;fill:#1a5fb4;fill-opacity:1;stroke:none;stroke-width:0.85391253;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 48,28 c -7.756,0 -14,6.244 -14,14 0,0.337684 0.0275,0.668439 0.05078,1 C 34.562237,35.716191 40.581684,30 48,30 h 32 c 7.418316,0 13.437763,5.716191 13.949219,13 C 93.9725,42.668439 94,42.337684 94,42 94,34.244 87.756,28 80,28 Z"
+           transform="translate(0,172)"
+           id="rect1790" />
+        <rect
+           ry="14"
+           rx="14"
+           y="202"
+           x="-94"
+           height="28"
+           width="59.999996"
+           id="rect1143"
+           style="opacity:1;vector-effect:none;fill:#3584e4;fill-opacity:1;stroke:none;stroke-width:0.85391253;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           transform="scale(-1,1)" />
+        <g
+           id="g1151"
+           transform="matrix(-1,0,0,1,130,-4)">
+          <circle
+             transform="translate(0,4)"
+             r="14"
+             cy="218"
+             cx="50"
+             id="circle1147"
+             style="opacity:1;vector-effect:none;fill:#deddda;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             clip-path="url(#clipPath1784)" />
+          <rect
+             style="opacity:1;vector-effect:none;fill:#deddda;fill-opacity:1;stroke:none;stroke-width:0.88191712;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             id="rect1149"
+             width="28"
+             height="5.9999995"
+             x="36"
+             y="216" />
+        </g>
+        <circle
+           r="14"
+           cy="212"
+           cx="-80"
+           id="circle1153"
+           style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.77777779;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           transform="scale(-1,1)" />
+      </g>
+      <g
+         transform="matrix(-1,0,0,1,128,38)"
+         id="g1818">
+        <path
+           transform="translate(0,172)"
+           id="path1804"
+           d="m 48,28 c -7.756,0 -14,6.244 -14,14 0,0.337684 0.0275,0.668439 0.05078,1 C 34.562237,35.716191 40.581684,30 48,30 h 32 c 7.418316,0 13.437763,5.716191 13.949219,13 C 93.9725,42.668439 94,42.337684 94,42 94,34.244 87.756,28 80,28 Z"
+           style="opacity:1;vector-effect:none;fill:#9a9996;fill-opacity:1;stroke:none;stroke-width:0.85391253;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <rect
+           ry="14"
+           rx="14"
+           y="202"
+           x="-94"
+           height="28"
+           width="59.999996"
+           id="rect1808"
+           style="opacity:1;vector-effect:none;fill:#c0bfbc;fill-opacity:1;stroke:none;stroke-width:0.85391253;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           transform="scale(-1,1)" />
+        <g
+           transform="matrix(-1,0,0,1,130,-4)"
+           id="g1814">
+          <circle
+             clip-path="url(#clipPath1784)"
+             style="opacity:1;vector-effect:none;fill:#deddda;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             id="circle1810"
+             cx="50"
+             cy="218"
+             r="14"
+             transform="translate(0,4)" />
+          <rect
+             y="216"
+             x="36"
+             height="5.9999995"
+             width="28"
+             id="rect1812"
+             style="opacity:1;vector-effect:none;fill:#deddda;fill-opacity:1;stroke:none;stroke-width:0.88191712;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        </g>
+        <circle
+           transform="scale(-1,1)"
+           style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.77777779;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="circle1816"
+           cx="-80"
+           cy="212"
+           r="14" />
+      </g>
     </g>
   </g>
 </svg>


### PR DESCRIPTION
The current icon is leftover from the fork of postmarketOS tweaks and contains postmarketOS branding. The icon I'm proposing is from GNOME Tweaks, which fits in better with Phosh and distinguishes this fork from the upstream and it's out of place branding.